### PR TITLE
added browserlist in package.json & improved import for createBrowserHistory()

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,11 @@
     "redux-thunk": "2.3.0",
     "sanitize.css": "7.0.3",
     "serve": "10.1.2"
-  }
+  },
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not ie <= 11",
+    "not op_mini all"
+  ]
 }

--- a/src/store.js
+++ b/src/store.js
@@ -1,10 +1,10 @@
 import { createStore, applyMiddleware, compose } from 'redux'
 import { connectRouter, routerMiddleware } from 'connected-react-router'
 import thunk from 'redux-thunk'
-import createHistory from 'history/createBrowserHistory'
+import * as History from 'history'
 import rootReducer from './modules'
 
-export const history = createHistory()
+export const history = History.createBrowserHistory()
 
 const initialState = {}
 const enhancers = []


### PR DESCRIPTION
1. Added "browserlist" in package.json because as of react-scripts >= 2 target browsers are must be specified.
<br/>

![Screenshot (66)](https://user-images.githubusercontent.com/29678865/62515015-a9eee680-b83e-11e9-9b7c-5d233502b067.png)

2. Improved import of createBrowserHistory() because support of `require('history/createBrowserHistory')` will be removed in next major relese.
<br/>

![Screenshot (65)](https://user-images.githubusercontent.com/29678865/62515032-b5421200-b83e-11e9-9338-3fa9d61f9e5e.png)

